### PR TITLE
handle signal SIGUSR1

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,16 @@
 
 #include <QtWidgets/QApplication>
 
+#include <signal.h>
+
+SystemTray* globalTray;
+
+void handleSignal(int signum)
+{
+    if (signum == SIGUSR1)
+        globalTray->onSuspend();
+}
+
 int main(int argc, char *argv[])
 {
     Q_INIT_RESOURCE(resources);
@@ -17,6 +27,9 @@ int main(int argc, char *argv[])
 
     if (!tray.StartRedshift())
         return 1;
+
+    globalTray = &tray;
+    signal(SIGUSR1, handleSignal);
 
     return a.exec();
 }

--- a/systemtray.h
+++ b/systemtray.h
@@ -20,6 +20,7 @@ public:
     bool StartRedshift();
     void ToggleRedshift(bool enable = true);
     void StopRedshift();
+    void onSuspend();
 
 private:
     void CreateMenu();
@@ -30,7 +31,6 @@ private:
     void onRedshiftQuit(int, QProcess::ExitStatus);
     void onRedshiftOutput();
 
-    void onSuspend();
     // FIXME: this looks bad
     void onSuspend10minutes();
     void onSuspend1hour();


### PR DESCRIPTION
Hi, I added the functionality to handle the SIGUSR1 signal.
Now it doesn't crash and toggle the tray icon properly when receives that signal.
I really tried to not use globals, but it seems that it's not possible to use signal inside an object.