### PR TITLE
Call setApplicationName() to set tray icon title

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,6 @@
 #include "systemtray.h"
 
 #include <QtWidgets/QApplication>
-#include <QCoreApplication>
 #include <QSharedMemory>
 #include <QDebug>
 
@@ -40,7 +39,7 @@ int main(int argc, char *argv[])
         return -1;
 
     QApplication a(argc, argv);
-    QCoreApplication::setApplicationName("Redshift Qt");
+    a.setApplicationName("Redshift Qt");
     QApplication::setQuitOnLastWindowClosed(false);
 
     SystemTray tray;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include "systemtray.h"
 
 #include <QtWidgets/QApplication>
+#include <QCoreApplication>
 #include <QSharedMemory>
 #include <QDebug>
 
@@ -39,6 +40,7 @@ int main(int argc, char *argv[])
         return -1;
 
     QApplication a(argc, argv);
+    QCoreApplication::setApplicationName("Redshift Qt");
     QApplication::setQuitOnLastWindowClosed(false);
 
     SystemTray tray;


### PR DESCRIPTION
At least on KDE Plasma, If we don't call `QCoreApplication::setApplicationName()`, the title of the tray icon will be set to the name of the binary instead of the "real" program name.

Before:

![Screenshot_20190921_041826](https://user-images.githubusercontent.com/626206/65369875-3a378e00-dc29-11e9-8c24-ac8168f21470.png)

After:

![Screenshot_20190921_042502](https://user-images.githubusercontent.com/626206/65369876-3d327e80-dc29-11e9-89fb-45bcdc5f1ecc.png)