### PR TITLE
Allow parameters

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -32,6 +32,23 @@ bool IsInstanceAlreadyRunning(QSharedMemory &memoryLock) {
 
 int main(int argc, char *argv[])
 {
+    QStringList argsl = QStringList();
+    bool varg = false;
+
+    for (int i = 1; i < argc; ++i){
+        if(std::string(argv[i]) == "-h" || std::string(argv[i]) == "--help"){
+            qInfo() <<  "Please run `redshift -h` for help output.";
+            exit(-1);
+        }
+
+        if(std::string(argv[i]) == "-v")
+           varg = true;
+
+        argsl.append(argv[i]);
+    }
+    if(!varg)
+       argsl.append("-v");
+       
     Q_INIT_RESOURCE(resources);
 
     QSharedMemory sharedMemoryLock("redshift-qt-lock");
@@ -48,7 +65,7 @@ int main(int argc, char *argv[])
     if (!tray.CreateIcon())
         return 1;
 
-    if (!tray.StartRedshift())
+    if (!tray.StartRedshift(argsl))
         return 1;
 
     globalTray = &tray;

--- a/systemtray.cpp
+++ b/systemtray.cpp
@@ -133,13 +133,13 @@ bool SystemTray::CreateIcon()
     return true;
 }
 
-bool SystemTray::StartRedshift()
+bool SystemTray::StartRedshift(QStringList argsl)
 {
     _redshiftProcess = new QProcess(this);
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     env.insert("LC_ALL", "C");
     _redshiftProcess->setProcessEnvironment(env);
-    _redshiftProcess->start("redshift -v");
+    _redshiftProcess->start("redshift", argsl);
 
     connect(_redshiftProcess, static_cast<void (QProcess::*)(int,QProcess::ExitStatus)>(&QProcess::finished), this, &SystemTray::onRedshiftQuit);
     connect(_redshiftProcess, &QProcess::readyRead, this, &SystemTray::onRedshiftOutput);

--- a/systemtray.h
+++ b/systemtray.h
@@ -15,7 +15,7 @@ public:
     SystemTray();
 
     bool CreateIcon();
-    bool StartRedshift();
+    bool StartRedshift(QStringList);
     void ToggleRedshift(bool enable = true);
     void StopRedshift();
     void onSuspend();


### PR DESCRIPTION
Allow to give parameters (like -l 30:30) and pass them directly to redshift (same as redshift-gtk). Check if -v is present, if not is added. If -h or --help is in the parameters, tell to ask for help directly in redshift and exit.
This will allow to give fixed position (when no internet for geoclue is available), use a custom config file, etc...